### PR TITLE
Update tanks and pumps

### DIFF
--- a/Pump/doc/spec.md
+++ b/Pump/doc/spec.md
@@ -51,13 +51,6 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   Values are resrtricted to: "OPEN","CLOSED","CV"
     -   Optional
 
--   `head` : Dynamic head gain by the pump
-
-    -   Attribute type: `Property`.Text
-    -   Attribute metadata Properties:
-        -   `{{metadata Property name}}` : {{Metadata Property Description}}
-    -   Mandatory if the `power` attribute does not exist
-
 -   `power` : The power supplied by the pump
 
     -   Attribute type: `Property`. Number
@@ -66,7 +59,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   [CEFACT](https://www.unece.org/cefact.html) unitCode: `KWT`
     -   Attribute metadata Properties:
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
-    -   Mandatory if the `head` attribute does not exist
+    -   Mandatory if the `headCurve` attribute does not exist
 
 -   `speed` : The relative speed setting of the pump 
 
@@ -112,12 +105,12 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
--   `pumpCurve` : The ID label of the pump curve used to describe the relationship between the head delivered by the pump and the flow through the pump
+-   `headCurve` : The ID label of the pump curve used to describe the relationship between the head delivered by the pump and the flow through the pump
 
     -   Attribute type: `Relationship`. Reference to an entity of type `Curve`
     -   Attribute metadata Properties:
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
-    -   Mandatory
+    -   Mandatory if the `power` attribute does not exist
 
 -   `pumpPattern` : The ID label of a time pattern used to control the pump's operation. The multipliers of the pattern are equivalent to speed settings. A multiplier of zero implies that the pump will be shut off during the corresponding time period
 

--- a/Pump/example-normalized-ld.jsonld
+++ b/Pump/example-normalized-ld.jsonld
@@ -11,10 +11,6 @@
         "type": "Property",
         "value": "OPEN"
     },
-    "head": {
-        "type": "Property",
-        "value": "curve1"
-    },
     "power": {
         "type": "Property",
         "value": 100,
@@ -36,10 +32,6 @@
     "tag": {
         "type": "Property",
         "value": "DMA1"
-    },
-    "pumpCurve":{
-        "type": "Relationship",
-        "object": "urn:ngsi-ld:Curve:fAM-8ca3-4533-a2eb-12015"
     },
     "pumpPattern":{
         "type": "Relationship",

--- a/Pump/schema.json
+++ b/Pump/schema.json
@@ -64,9 +64,6 @@
                 "initialStatus": {
                     "$ref": "#/definitions/status"
                 },
-                "head": {
-                    "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
-                },
                 "power": {
                     "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
@@ -82,7 +79,7 @@
                 "tag": {
                     "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
-                "pumpCurve": {
+                "headCurve": {
                     "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"
                 },
                 "pumpPattern": {
@@ -116,10 +113,7 @@
         "id",
         "type",
         "initialStatus",
-        "head",
         "startsAt",
-        "endsAt",
-        "pumpCurve",
-        "pumpPattern"
+        "endsAt"
     ]
 }

--- a/Tank/doc/spec.md
+++ b/Tank/doc/spec.md
@@ -120,11 +120,9 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Values Restricted to :  "MIXED", "2COMP", "FIFO" and "LIFO"
     -   Mandatory
 
--   `volumCurve` : The ID label of a curve used to describe the relation between tank volume and water level
-    -   Attribute type: `Property`. Number
+-   `volumeCurve` : The ID label of a curve used to describe the relation between tank volume and water level
+    -   Attribute type: `Relationship`. Reference to an entity of type `Curve`
     -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
-    -   Attribute unit Example: `cubic metre`
-    -   [CEFACT](https://www.unece.org/cefact.html) unitCode: `MTQ`
     -   Attribute metadata Properties:
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional

--- a/Tank/example-normalized-ld.jsonld
+++ b/Tank/example-normalized-ld.jsonld
@@ -73,10 +73,9 @@
         "type": "Property",
         "value": "MIXED"
     },
-    "volumCurve": {
-        "type": "Property",
-        "value": 200,
-        "unitCode": "MTQ"
+    "volumeCurve": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Curve:fAM-8ca3-4533-a2eb-12015"
     },
     "mixingFraction": {
         "type": "Property",

--- a/Tank/schema.json
+++ b/Tank/schema.json
@@ -251,8 +251,8 @@
                 "sourceCategory": {
                     "$ref": "#/definitions/source"
                 },
-                "volumCurve": {
-                    "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
+                "volumeCurve": {
+                    "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"
                 },
                 "mixingFraction": {
                     "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"


### PR DESCRIPTION
Pumps:
* Remove attributes from mandatory list that do not have do be specified or cannot be specified simultaneously.
* Remove `head` attribute, as if a `head` is specified in the EPANET network model this is a head curve. Rename the `pumpCurve` attribute as `headCurve`.
* Remove `headCurve` attribute from example, as either `headCurve` or `power` is required, not both.

Tanks:
* Change `volumCurve` to `volumeCurve`
* Change tank `volumeCurve` attrubute from a property to a relationship (to a curve).